### PR TITLE
feat: add color change button

### DIFF
--- a/app/Palacinkyy/header.jsx
+++ b/app/Palacinkyy/header.jsx
@@ -1,6 +1,18 @@
 import { Link } from "@remix-run/react";
+import { useState, useEffect } from "react";
 
 export default function Header() {
+  const colors = ["#f8f5f2", "#d1f7c4", "#fddde6", "#e0f7fa", "#ffe4b5"];
+  const [colorIndex, setColorIndex] = useState(0);
+
+  useEffect(() => {
+    document.body.style.backgroundColor = colors[colorIndex];
+  }, [colorIndex]);
+
+  function changeColor() {
+    setColorIndex((colorIndex + 1) % colors.length);
+  }
+
   return (
     <header>
       <h1>Recepty</h1>
@@ -8,6 +20,9 @@ export default function Header() {
         <Link to="/">Domů</Link>
         <Link to="/about">O aplikaci</Link>
       </nav>
+      <button type="button" onClick={changeColor}>
+        Změnit barvu
+      </button>
     </header>
   );
 }

--- a/app/styles.css
+++ b/app/styles.css
@@ -54,7 +54,7 @@ form input {
   border-radius: 4px;
 }
 
-form button {
+button {
   padding: 0.5rem 1rem;
   background: #ffcc66;
   border: none;
@@ -62,6 +62,6 @@ form button {
   cursor: pointer;
 }
 
-form button:hover {
+button:hover {
   background: #ffb347;
 }


### PR DESCRIPTION
## Summary
- add header button to cycle page background colors
- style all buttons consistently

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ab6d8858d48322a5aef4a917126d5f