### PR TITLE
Handle DB connection errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
-DB_HOST=
-DB_USER=
-DB_PASSWORD=
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=username
+DB_PASSWORD=password
 DB_NAME=2it_simkovicp22

--- a/README.md
+++ b/README.md
@@ -4,18 +4,27 @@ This is a simple blog built with the Remix framework. It loads posts from a MySQ
 
 ## Database
 
-Create a `posts` table on your MySQL server with the following columns:
+Create a `blogN` table on your MySQL server with the following columns:
 
 ```sql
-CREATE TABLE posts (
+CREATE TABLE blogN (
   id INT AUTO_INCREMENT PRIMARY KEY,
-  title VARCHAR(120) NOT NULL,
-  content TEXT NOT NULL,
-  created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+  Titulek VARCHAR(120) NOT NULL,
+  text TEXT NOT NULL
 );
 ```
 
-Set the database connection credentials in environment variables `DB_HOST`, `DB_USER`, `DB_PASSWORD` and `DB_NAME`.
+Copy `.env.example` to `.env` and adjust as needed. The example configuration connects to a local MySQL server and exposes the common connection settings:
+
+```
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=username
+DB_PASSWORD=password
+DB_NAME=2it_simkovicp22
+```
+
+These values map directly to the `DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD` and `DB_NAME` environment variables used by the app. Update them to match your own MySQL server. If the connection fails, the server will log the underlying error to help with troubleshooting.
 
 ## Development
 

--- a/app/components/Blog.tsx
+++ b/app/components/Blog.tsx
@@ -16,7 +16,7 @@ export default function Blog({ posts }: BlogProps) {
       <ul>
         {posts.map((post) => (
           <li key={post.id}>
-            <Link to={`/posts/${post.id}`}>{post.title}</Link>
+            <Link to={`/item?id=${post.id}`}>{post.title}</Link>
           </li>
         ))}
       </ul>

--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -1,35 +1,47 @@
 import mysql from 'mysql2/promise';
 
 export async function getConnection() {
-  return mysql.createConnection({
-    host: process.env.DB_HOST,
-    user: process.env.DB_USER,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME,
-  });
+  try {
+    return await mysql.createConnection({
+      host: process.env.DB_HOST,
+      port: Number(process.env.DB_PORT) || 3306,
+      user: process.env.DB_USER,
+      password: process.env.DB_PASSWORD,
+      database: process.env.DB_NAME,
+      connectTimeout: 5000,
+    });
+  } catch (error) {
+    console.error('Database connection failed', error);
+    throw error;
+  }
 }
 
 export async function getPosts() {
   const conn = await getConnection();
-  const [rows] = await conn.query(
-    'SELECT id, title, created_at FROM posts ORDER BY created_at DESC'
-  );
-  await conn.end();
-  return rows as { id: number; title: string; created_at: Date }[];
+  try {
+    const [rows] = await conn.query(
+      "SELECT id, Titulek AS title FROM blogN ORDER BY id DESC"
+    );
+    return rows as { id: number; title: string }[];
+  } finally {
+    await conn.end();
+  }
 }
 
 export async function getPost(id: number) {
   const conn = await getConnection();
-  const [rows] = await conn.query(
-    'SELECT id, title, content, created_at FROM posts WHERE id = ?',
-    [id]
-  );
-  await conn.end();
-  const posts = rows as {
-    id: number;
-    title: string;
-    content: string;
-    created_at: Date;
-  }[];
-  return posts[0];
+  try {
+    const [rows] = await conn.query(
+      "SELECT id, Titulek AS title, `text` AS content FROM blogN WHERE id = ?",
+      [id]
+    );
+    const posts = rows as {
+      id: number;
+      title: string;
+      content: string;
+    }[];
+    return posts[0];
+  } finally {
+    await conn.end();
+  }
 }

--- a/app/routes/item.tsx
+++ b/app/routes/item.tsx
@@ -2,8 +2,10 @@ import type { LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData } from '@remix-run/react';
 import { getPost } from '../db.server';
 
-export async function loader({ params }: LoaderFunctionArgs) {
-  const id = Number(params.id);
+export async function loader({ request }: LoaderFunctionArgs) {
+  const url = new URL(request.url);
+  const idParam = url.searchParams.get('id');
+  const id = idParam ? Number(idParam) : NaN;
   if (isNaN(id)) {
     throw new Response('Not Found', { status: 404 });
   }
@@ -14,7 +16,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
   return post;
 }
 
-export default function PostRoute() {
+export default function ItemRoute() {
   const post = useLoaderData<typeof loader>();
   return (
     <article>


### PR DESCRIPTION
## Summary
- add DB_PORT to environment sample and README
- log database connection failures and allow port configuration

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68ac233071cc832293e776003294d419